### PR TITLE
Fix node registration and re-registration after hub restart

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -1,44 +1,47 @@
 var fs = require('fs'),
     util = require('util'),
-    chalk = require('chalk');
+    chalk = require('chalk'),
+    tracer = require('tracer');
 
 function chalkStyle(style) {
-    return function(str, o) {
+    return function(data) {
         return util.format(
             '%s %s %s',
-            chalk.gray(o.timestamp),
-            chalk.gray(o.file + ':' + o.line),
-            chalk[style]('[' + o.title + ']: ' + o.message)
+            chalk.gray(data.timestamp),
+            chalk.gray(data.file + ':' + data.line),
+            chalk[style]('[' + data.title + ']: ' + data.message)
         );
     }
 }
 
-var logger = require('tracer')
-        .colorConsole({
-            level: 'info',
-            format: '{{timestamp}} {{file}}:{{line}} {{title}}: {{message}}',
-            dateformat: 'HH:MM:ss.L',
-            filters: {
-                info: chalkStyle('white'),
-                warn: chalkStyle('yellow'),
-                debug: chalkStyle('blue'),
-                error: chalkStyle('red')
-            }
-        }),
+var filters = {
+        info: chalkStyle('white'),
+        warn: chalkStyle('yellow'),
+        debug: chalkStyle('blue'),
+        error: chalkStyle('red')
+    },
+    logger = tracer.console({
+        level: 'info',
+        format: '{{timestamp}} {{file}}:{{line}} {{title}}: {{message}}',
+        dateformat: 'HH:MM:ss.L',
+        transport: function(data) {
+            var filter = filters[data.title] || filters.info;
+            console.log(filter(data));
+        }
+    }),
 
     logFile = fs.createWriteStream('./file_' + process.pid + '.log', {flags: 'a'}),
-    fileLogger = require('tracer')
-        .console({
-            transport: function(data) {
-                try {
-                    logFile.write(data.output + '\n');
-                } catch (err) {
-                    console.log('Error logging');
-                    console.log(err.message);
-                    console.trace('error logging');
-                }
+    fileLogger = tracer.console({
+        transport: function(data) {
+            try {
+                logFile.write(data.output + '\n');
+            } catch (err) {
+                console.log('Error logging');
+                console.log(err.message);
+                console.trace('error logging');
             }
-        });
+        }
+    });
 
 exports.info = function(e) {
     var msg = util.format.apply(null, arguments);

--- a/lib/servlets/apiProxy.js
+++ b/lib/servlets/apiProxy.js
@@ -8,7 +8,8 @@ module.exports = function(req, res) {
         log.warn('Returning error message: ' + msg);
 
         return {
-            status: 404,
+            // selenium-server expects 200 status with success=false
+            status: 200,
             headers: {},
             data: {msg: msg, success: false}
         }
@@ -22,7 +23,8 @@ module.exports = function(req, res) {
         .then(function(node) {
             if (!node) {
                 return {
-                    status: 404,
+                    // selenium-server expects 200 status with success=false
+                    status: 200,
                     headers: {},
                     data: {
                         msg: util.format('Cannot find proxy with ID=http://%s:%s in the registry.', host, port),

--- a/lib/servlets/register.js
+++ b/lib/servlets/register.js
@@ -4,19 +4,31 @@ var q = require('q'),
     apps = require('../http-apps');
 
 module.exports = function(req, res) {
-    if (!req.data) {
-        return q.reject(apps.content('Invalid parameters', 'text/plain', 400));
-    }
-
-    return q.invoke(registry, 'addNode', req.data)
+    return q(req.data)
+        .then(function(data) {
+            if (!data && req.headers['content-type'].indexOf('text/plain') > -1) {
+                return req.body.read()
+                    .then(function(body) {
+                        return JSON.parse(body);
+                    });
+            }
+            return data;
+        })
         .catch(function() {
             return q.reject(apps.content('Invalid parameters', 'text/plain', 400));
         })
-        .then(function(success) {
-            if (success) {
-                log.info('Register new node: %s', JSON.stringify(req.data));
-                return apps.content('ok');
-            }
-            return q.reject(apps.content('Invalid parameters', 'text/plain', 400));
+        .then(function(data) {
+            return q.invoke(registry, 'addNode', data)
+                .catch(function(err) {
+                    log.warn(err.stack || err);
+                    return q.reject(apps.content('Invalid parameters', 'text/plain', 400));
+                })
+                .then(function(success) {
+                    if (success) {
+                        log.info('Register new node: %s', JSON.stringify(data));
+                        return apps.content('ok');
+                    }
+                    return q.reject(apps.content('Invalid parameters', 'text/plain', 400));
+                });
         });
 };

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "q-io": "^1.12.0",
     "qs": "^2.3.3",
     "server-destroy": "^1.0.0",
-    "tracer": "*"
+    "tracer": "^0.7.4"
   },
   "devDependencies": {
     "coveralls": "^2.11.2",

--- a/test/servlets/apiProxy.js
+++ b/test/servlets/apiProxy.js
@@ -27,7 +27,7 @@ describe('apiProxyServlet', function() {
                 // query for the node id
                 return tester
                     .get('/grid/api/proxy?id=' + nodeUrl)
-                    .expect(404, {
+                    .expect(200, {
                         msg: 'Cannot find proxy with ID=' + nodeUrl + ' in the registry.',
                         success: false
                     });
@@ -94,7 +94,7 @@ describe('apiProxyServlet', function() {
                         return tester
                             // query for the node id
                             .get('/grid/api/proxy?id=' + nodeUrl)
-                            .expect(404, {
+                            .expect(200, {
                                 msg: 'Cannot find proxy with ID=' + nodeUrl + ' in the registry.',
                                 success: false
                             });
@@ -110,7 +110,7 @@ describe('apiProxyServlet', function() {
                         // query for the node id
                         return tester
                             .get('/grid/api/proxy?id=' + nodeUrl)
-                            .expect(404, {
+                            .expect(200, {
                                 msg: 'Cannot find proxy with ID=' + nodeUrl + ' in the registry.',
                                 success: false
                             });


### PR DESCRIPTION
- Try to parse request body as JSON even if the `Content-Type` is `text/plain`
- Always return response with `200` status code for `/grid/api/proxy`
- Fix logging after `tracer 0.7.4` release
