### PR TITLE
Fix proxy sending incorrect headers to a node

### DIFF
--- a/lib/http-apps.js
+++ b/lib/http-apps.js
@@ -48,7 +48,9 @@ function processJsonBody(obj) {
             if (contentType && contentType.indexOf('json') > -1) {
                 return obj.body.read()
                     .then(function(body) {
-                        obj.data = JSON.parse(body);
+                        if (body.length) {
+                            obj.data = JSON.parse(body);
+                        }
                         return obj;
                     });
             }
@@ -76,7 +78,9 @@ function processUrlEncodedBody(obj) {
             if (contentType && contentType.indexOf('x-www-form-urlencoded') > -1) {
                 return obj.body.read()
                     .then(function(body) {
-                        obj.data = qs.parse(body.toString());
+                        if (body.length) {
+                            obj.data = qs.parse(body.toString());
+                        }
                         return obj;
                     });
             }

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -2,6 +2,7 @@
 
 var q = require('q'),
     http = require('q-io/http'),
+    qs = require('qs'),
     log = require('./log');
 
 function proxy(req, node, retryCounter) {
@@ -15,9 +16,20 @@ function proxy(req, node, retryCounter) {
             port: node.port,
             method: req.method,
             path: req.path,
-            headers: req.headers,
-            body: req.data ? [JSON.stringify(req.data)] : req.body
+            headers: {}
         };
+
+    var contentType = req.headers && req.headers['content-type'];
+    if (req.data && contentType) {
+        opts.headers['content-type'] = contentType;
+        if (contentType.indexOf('json') > -1) {
+            opts.body = [JSON.stringify(req.data)];
+        } else if (contentType.indexOf('x-www-form-urlencoded') > -1) {
+            opts.body = [qs.stringify(req.data)];
+        }
+    } else {
+        opts.body = req.body;
+    }
 
     // use separate pool (agent) for each node
     if (typeof node.getAgent === 'function') {


### PR DESCRIPTION
`proxy` module fixes:
- do not set `Content-Length` header
- set correct `Content-Type` header
- serialize body using `Content-Type` aware serializer

`http-apps` module fixes:
- parse request body only when it size > 0

Closes #30 

/cc @TheFifthFreedom
