### PR TITLE
Drop Content-Length header on JSON responses from node

### DIFF
--- a/lib/driver/CommonImpl.js
+++ b/lib/driver/CommonImpl.js
@@ -75,6 +75,6 @@ module.exports = inherit(/** @lends CommonImpl.prototype */ {
                 log.warn("Session stopped");
             }
         }*/
-        return apps.processJsonBody(proxy(req, node));
+        return apps.processJsonBody(proxy(req, node), /*dropContentLengthHeader*/ true);
     }
 });

--- a/lib/http-apps.js
+++ b/lib/http-apps.js
@@ -41,7 +41,7 @@ function HandleJsonRequests(app) {
     }
 }
 
-function processJsonBody(obj) {
+function processJsonBody(obj, dropContentLengthHeader) {
     return q(obj)
         .then(function(obj) {
             var contentType = obj.headers['content-type'];
@@ -50,6 +50,9 @@ function processJsonBody(obj) {
                     .then(function(body) {
                         if (body.length) {
                             obj.data = JSON.parse(body);
+                        }
+                        if (dropContentLengthHeader) {
+                            delete obj.headers['content-length'];
                         }
                         return obj;
                     });
@@ -71,7 +74,7 @@ function HandleUrlEncodedRequests(app) {
     }
 }
 
-function processUrlEncodedBody(obj) {
+function processUrlEncodedBody(obj, dropContentLengthHeader) {
     return q(obj)
         .then(function(obj) {
             var contentType = obj.headers['content-type'];
@@ -80,6 +83,9 @@ function processUrlEncodedBody(obj) {
                     .then(function(body) {
                         if (body.length) {
                             obj.data = qs.parse(body.toString());
+                        }
+                        if (dropContentLengthHeader) {
+                            delete obj.headers['content-length'];
                         }
                         return obj;
                     });


### PR DESCRIPTION
This is needed to reply with correct Content-Length after JSON serialization.

Closes #38
